### PR TITLE
extensions: Search all possible paths

### DIFF
--- a/extensions.c
+++ b/extensions.c
@@ -19,7 +19,7 @@
 #include <dlfcn.h>
 
 static int in_extensions_library(char *, char *);
-static char *get_extensions_directory(char *);
+static char *get_extensions_directory(char *, bool *);
 static void show_all_extensions(void);
 static void show_extensions(char *);
 
@@ -395,32 +395,29 @@ in_extensions_library(char *lib, char *buf)
  * Look for an extensions directory using the proper order. 
  */
 static char *
-get_extensions_directory(char *dirbuf)
+get_extensions_directory(char *dirbuf, bool *end)
 {
-	char *env;
+	static int index = 0;
+	char *dirs[] = {
+		getenv("CRASH_EXTENSIONS"),
+		BITS64() ? "/usr/lib64/crash/extensions" : NULL,
+		"/usr/lib/crash/extensions",
+		"./extensions",
+	};
+	char *dir;
 
-	if ((env = getenv("CRASH_EXTENSIONS"))) {
-		if (is_directory(env)) {
-			strcpy(dirbuf, env);
-			return dirbuf;
-		}
+	if (index >= sizeof(dirs) / sizeof(char *)) {
+		*end = true;
+		return NULL;
 	}
-
-	if (BITS64()) {
-		sprintf(dirbuf, "/usr/lib64/crash/extensions");
-		if (is_directory(dirbuf))
-			return dirbuf;
+	*end = false;
+	dir = dirs[index++];
+	if (is_directory(dir)) {
+		snprintf(dirbuf, BUFSIZE - 1, "%s", dir);
+		return dir;
+	} else {
+		return NULL;
 	}
-
-       	sprintf(dirbuf, "/usr/lib/crash/extensions");
-	if (is_directory(dirbuf))
-		return dirbuf;
- 
-       	sprintf(dirbuf, "./extensions");
-	if (is_directory(dirbuf))
-		return dirbuf;
-
-	return NULL;
 }
 
 
@@ -432,14 +429,20 @@ preload_extensions(void)
 	char dirbuf[BUFSIZE];
 	char filename[BUFSIZE*2];
 	int found;
+	bool end;
 
-	if (!get_extensions_directory(dirbuf))
-		return;
+next_dir:
+	if (!get_extensions_directory(dirbuf, &end)) {
+		if (end)
+			return;
+		else
+			goto next_dir;
+	}
 
         dirp = opendir(dirbuf);
 	if (!dirp) {
 		error(INFO, "%s: %s\n", dirbuf, strerror(errno));
-		return;
+		goto next_dir;
 	}
 
 	pc->curcmd = pc->program_name;
@@ -461,10 +464,12 @@ preload_extensions(void)
 	
 	if (found)
 		fprintf(fp, "\n");
-	else
+	else {
 		error(NOTE, 
 		    "%s: no extension modules found in directory\n\n",
 			dirbuf);
+		goto next_dir;
+	}
 }
 
 /*

--- a/extensions/eppic.mk
+++ b/extensions/eppic.mk
@@ -53,7 +53,14 @@ all:
 			fi; \
 			if  [ -f $(APPFILE) ]; \
 			then \
-				make -f eppic.mk eppic.so; \
+				if patch --dry-run -N -p0 < eppic.patch >/dev/null ; then \
+					patch -N -p0 < eppic.patch; \
+					make -f eppic.mk eppic.so; \
+				elif patch --dry-run -N -p0 -R < eppic.patch >/dev/null ; then \
+					make -f eppic.mk eppic.so; \
+				else \
+					echo "eppic.so: apply eppic.patch error"; \
+				fi; \
 			else \
 				echo "eppic.so: failed to pull eppic code from git repo"; \
 			fi; \

--- a/extensions/eppic.patch
+++ b/extensions/eppic.patch
@@ -1,0 +1,210 @@
+--- eppic/applications/crash/eppic.c
++++ eppic/applications/crash/eppic.c
+@@ -20,6 +20,7 @@
+ #include "defs.h"
+ 
+ #include <eppic_api.h>
++#include "eppic.h"
+ 
+ /*
+  *  Global data (global_data.c) 
+@@ -788,6 +789,39 @@ char *sclass_help[]={
+                 NULL
+ };
+ 
++char *eppic_help[]={
++		"eppic",
++                "Run eppic program(es).",
++                "<fileName1.c>[, <fileName2.c>]",
++                "  Oneshot run eppic program(es) which with a main() entry each.",
++                NULL
++};
++
++void
++eppic_command(void)
++{
++	char *buf;
++	optind = 1;
++
++	if (!args[optind]) {
++		cmd_usage(crash_global_cmd(), SYNOPSIS);
++		return;
++	}
++
++	while(args[optind]) {
++		buf = eppic_filempath(args[optind]);
++		if (!buf) {
++			eppic_msg("eppic_filempath error on %s\n", args[optind]);
++			return;
++		}
++		eppic_load(buf);
++		if (eppic_findfile(buf, 0))
++			eppic_unload(buf);
++		eppic_free(buf);
++		optind++;
++	}
++}
++
+ #define NCMDS 200
+ static struct command_table_entry command_table[NCMDS] =  {
+ 
+@@ -797,6 +831,7 @@ static struct command_table_entry command_table[NCMDS] =  {
+ 	{"sdebug", sdebug_cmd, sdebug_help},
+ 	{"sname", sname_cmd, sname_help},
+ 	{"sclass", sclass_cmd, sclass_help},
++	{"eppic", eppic_command, eppic_help},
+ 	{(char *)0 }
+ };
+ 
+@@ -885,6 +920,13 @@ char **help=malloc(sizeof *help * 5);
+         }
+     }
+     free(help);
++
++    if (load && !strcmp(name, "main")) {
++        int optind_save = optind;
++        eppic_cmd(name, NULL, 0);
++        optind = optind_save;
++    }
++
+     return;
+ }
+ 
+--- eppic/libeppic/eppic_api.h
++++ eppic/libeppic/eppic_api.h
+@@ -16,6 +16,9 @@
+ /* minor and major version number 
+     4.0 switch to new Eppic name and use of fully typed symbols.
+ */
++#ifndef EPPIC_API_H
++#define EPPIC_API_H
++
+ #define S_MAJOR 5
+ #define S_MINOR 0
+ 
+@@ -298,3 +301,5 @@ void eppic_dbg_named(int class, char *name, int level, char *, ...);
+ 
+ /* parsers debug flags */
+ extern int eppicdebug, eppicppdebug;
++
++#endif
+\ No newline at end of file
+--- eppic/libeppic/eppic_func.c
++++ eppic/libeppic/eppic_func.c
+@@ -22,6 +22,8 @@
+ #include <sys/types.h>
+ #include <time.h>
+ #include <sys/stat.h>
++#include <fcntl.h>
++#include <unistd.h>
+ #include "eppic.h"
+ 
+ /*
+@@ -793,6 +795,42 @@ char *ed=getenv("EDITOR");
+     if(!system(buf)) eppic_load(fname);
+ }
+ 
++static const char *example[] = {
++"/*										",
++" * Example: Print all tasks' PID & command					",
++" *										",
++" * // Kernel's global variables and data structures can be used directly without",
++" * // pre-define it in kernel header. If any are within kernel modules, should",
++" * // preload the .ko first via \"mod -S/-s\" cmd in crash before invoke your",
++" * // eppic program.								",
++" * //										",
++" * // Eppic program's syntax is similar to C but with slight differences.	",
++" * // Code samples:								",
++" * // https://github.com/lucchouina/eppic/tree/master/applications/crash/code",
++" * // Available eppic functions:						",
++" * // https://github.com/lucchouina/eppic/blob/master/libeppic/eppic_builtin.c#L316",
++" *										",
++" * int main(void)								",
++" * {										",
++" *     struct task_struct *p;							",
++" *     unsigned long offset;							",
++" *										",
++" *     p = (struct task_struct *)&init_task;					",
++" *     offset = (unsigned long)&(p->tasks) - (unsigned long)p;		",
++" *										",
++" *     do {									",
++" *         printf(\"PID: %d Command: %s\\n\", (int)(p->pid), getstr((char *)&(p->comm[0])));",
++" *         p = (struct task_struct *)((unsigned long)(p->tasks.next) - offset);",
++" *     } while(p != &init_task);						",
++" * 										",
++" *     return 0;								",
++" * }										",
++" *										",
++" * crash> eppic program_file.c						",
++" */										",
++};
++
++char *eppic_get_func_file(char *);
+ /*
+     This funciton is called to start a vi session on a function
+     (file=0) or a file (file=1);
+@@ -800,24 +838,31 @@ char *ed=getenv("EDITOR");
+ void
+ eppic_vi(char *fname, int file)
+ {
+-int line, freeit=0;
++int line=1, freeit=0, fd;
+ char *filename;
++char newline = '\n';
+ 
+     if(file) {
+ 
+         filename=eppic_filempath(fname);
+ 
+         if(!filename) {
+-
+-            eppic_msg("File not found : %s\n", fname);
+-            return;
+-
+-        }
+-
+-        line=1;
+-        freeit=1;
+-
+-
++	    fd = creat(fname, 0644);
++	    if (fd < 0) {
++		eppic_msg("File not found : %s\n", fname);
++		return;
++	    } else {
++		for (int i = 0; i < sizeof(example)/sizeof(char *); i++) {
++			write(fd, example[i], strlen(example[i]));
++			write(fd, &newline, sizeof(newline));
++		}
++		close(fd);
++		filename = fname;
++		freeit=0;
++	    }
++        } else {
++            freeit=1;
++	}
+     } else {
+ 
+         func *f=eppic_getfbyname(fname, 0);
+@@ -837,6 +882,10 @@ char *filename;
+ 
+     eppic_exevi(filename, line);
+ 
++    char *fi_name = eppic_get_func_file("main");
++    if (fi_name)
++        eppic_deletefile(fi_name);
++
+     if(freeit) eppic_free(filename);
+ 
+ }
+@@ -1184,3 +1233,10 @@ eppic_runcmd(char *fname, var_t*args)
+     return 0;
+ }
+ 
++char *eppic_get_func_file(char *funcname)
++{
++	func *fn = eppic_getfbyname(funcname, 0);
++	if (!fn)
++		return NULL;
++	return fn->file->fname;
++}


### PR DESCRIPTION
Search all possible paths for extensions. Previously if one path, e.g. "/usr/lib64/crash/extensions" exists, but no extensions found within, crash will not search any later paths, e.g. "./extensions". This patch will let crash continue to search any later paths.